### PR TITLE
Add NL country support

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -268,3 +268,7 @@ msgstr ""
 msgctxt "#30066"
 msgid "Lithuanian"
 msgstr ""
+
+msgctxt "#30067"
+msgid "viaplay.com/nl"
+msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -268,3 +268,7 @@ msgstr ""
 msgctxt "#30066"
 msgid "Lithuanian"
 msgstr "Litewski"
+
+msgctxt "#30067"
+msgid "viaplay.com/nl"
+msgstr ""

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -268,3 +268,7 @@ msgstr ""
 msgctxt "#30066"
 msgid "Lithuanian"
 msgstr "Litauiska"
+
+msgctxt "#30067"
+msgid "viaplay.com/nl"
+msgstr ""

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -74,6 +74,7 @@ def generate_m3u():
     data = '#EXTM3U\n'
 
     country_code = helper.get_country_code()
+    tld = helper.get_tld()
     country_id = helper.get_setting('site')
     if country_id == '0':
         chann = 'kanaler'
@@ -86,7 +87,7 @@ def generate_m3u():
     elif country_id == '4':
         chann = 'channels'
 
-    url = 'https://content.viaplay.{c1}/xdk-{c2}/{chann}'.format(c1=country_code, c2=country_code, chann=chann)
+    url = 'https://content.viaplay.{c1}/xdk-{c2}/{chann}'.format(c1=tld, c2=country_code, chann=chann)
 
     response = helper.vp.make_request(url=url, method='get')
     channels_block = response['_embedded']['viaplay:blocks'][0]['_embedded']['viaplay:blocks']

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -71,7 +71,15 @@ class KodiHelper(object):
             country_code = 'pl'
         elif country_id == '5':
             country_code = 'lt'
+        elif country_id == '6':
+            country_code = 'nl'
 
+        return country_code
+
+    def get_tld(self):
+        country_code = self.get_country_code()
+        if country_code == "nl":
+            return "com"
         return country_code
 
     def dialog(self, dialog_type, heading, message=None, options=None, nolabel=None, yeslabel=None):

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,6 +1,6 @@
 ﻿<settings>
   <category label="30003">
-    <setting id="site" type="enum" label="30007" lvalues="30008|30009|30010|30011|30054|30065" default="0"/>
+    <setting id="site" type="enum" label="30007" lvalues="30008|30009|30010|30011|30054|30065|30067" default="0"/>
     <setting id="subtitles" type="bool" label="30012" default="true"/>
     <setting id="first_run" type="bool" default="true" visible="false"/>
 	<setting type="sep" />


### PR DESCRIPTION
Using viaplay.com domain, but NL country codes.
While viaplay.nl exists, not all APIs work on this domain and mostly it's used for redirecting to viaplay.com/nl.

Fixes https://github.com/emilsvennesson/kodi-viaplay/issues/54