### PR TITLE
Adding profile support

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.viaplay" version="2.3.2" name="Viaplay" provider-name="emilsvennesson, mariusz89b, heppen-dev, zuzia-dev">
+<addon id="plugin.video.viaplay" version="2.3.2" name="Viaplay" provider-name="emilsvennesson, mariusz89b, heppen-dev, zuzia-dev, beanow">
    <requires>
       <import addon="script.module.requests" version="2.9.1" />
       <import addon="script.module.iso8601" version="0.1.11" />

--- a/addon.xml
+++ b/addon.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <addon id="plugin.video.viaplay" version="2.3.2" name="Viaplay" provider-name="emilsvennesson, mariusz89b, heppen-dev, zuzia-dev">
    <requires>
       <import addon="script.module.requests" version="2.9.1" />
@@ -15,12 +15,13 @@
       <description lang="fi_FI">Katso sisältöä Viaplay.</description>
       <description lang="nb_NO">Se innhold fra Viaplay.</description>
       <description lang="sv_SE">Titta på innehåll från Viaplay.</description>
-	  <description lang="pl_PL">Oglądaj treści z Viaplay.</description>
-	  <description lang="lt_LT">Žiūrėkite turinį iš Viaplay.</description>
+      <description lang="pl_PL">Oglądaj treści z Viaplay.</description>
+      <description lang="lt_LT">Žiūrėkite turinį iš Viaplay.</description>
+      <description lang="nl_NL">Bekijk inhoud van Viaplay.</description>
       <news>2022.03.27 v2.3.2[CR]+ Fixed sports series event listing @heppen-dev[CR]2022.03.24 v2.3.1[CR]+ Add NL country support[CR]+ Fixed popular sport tiles[CR]2022.02.17 v2.3.0[CR]+ Added search history function[CR][CR]2022.02.16 v2.2.9[CR]+ Sport category fix[CR][CR]2022.01.28 v2.2.8[CR]+ Kids category updates[CR][CR]2022.01.27 v2.2.7[CR]+ Fixed logout[CR][CR]2022.01.27 v2.2.6[CR]+ Fixed login error[CR][CR]2022.01.25 v2.2.5[CR]+ Fixes[CR][CR]2022.01.23 v2.2.4[CR]+ Fixed external authorization[CR][CR]2021.11.09 v2.2.3[CR]+ Added viaplay.lt[CR][CR]2021.10.24 v2.2.2[CR]+ Fixed plot[CR][CR]2021.10.06 v2.2.1[CR]+ Fixed category sport matches abbreviations[CR][CR]2021.09.29 v2.2.0[CR]+ Fixed subtitles[CR][CR]2021.09.27 v2.1.9[CR]+ Fixed product categories[CR][CR]2021.08.17 v2.1.8[CR]+ Fixed html import error[CR][CR]2021.08.11 v2.1.7[CR]+ Fixed M3U playlist generator[CR][CR]2021.08.09 v2.1.6[CR]+ Added M3U playlist generator[CR][CR]2021.08.08 v2.1.5[CR]+ Added setting "Hide previously aired Live-Tv programmes"[CR][CR]2021.08.07 v2.1.4[CR]+ Added watched and purchased categories for viaplay.pl[CR]+ Fixed category error[CR][CR]2021.08.05 v.2.1.3[CR]+ Added viaplay.pl
       </news>
       <platform>all</platform>
-      <language>sv dk no fi en pl lt</language>
+      <language>sv dk no fi en pl lt nl</language>
       <license>GNU GENERAL PUBLIC LICENSE. Version 3, 29 June 2007</license>
       <source>https://github.com/emilsvennesson/kodi-viaplay</source>
       <forum>http://forum.kodi.tv/showthread.php?tid=286387</forum>

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -272,3 +272,11 @@ msgstr ""
 msgctxt "#30067"
 msgid "viaplay.com/nl"
 msgstr ""
+
+msgctxt "#30068"
+msgid "Select profile"
+msgstr ""
+
+msgctxt "#30069"
+msgid "Unable to load profiles, perhaps we're not logged in."
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -280,3 +280,19 @@ msgstr ""
 msgctxt "#30069"
 msgid "Unable to load profiles, perhaps we're not logged in."
 msgstr ""
+
+msgctxt "#30070"
+msgid "Adult"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Child"
+msgstr ""
+
+msgctxt "#30072"
+msgid "owner"
+msgstr ""
+
+msgctxt "#30073"
+msgid "age restricted"
+msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -272,3 +272,11 @@ msgstr "Litewski"
 msgctxt "#30067"
 msgid "viaplay.com/nl"
 msgstr ""
+
+msgctxt "#30068"
+msgid "Select profile"
+msgstr ""
+
+msgctxt "#30069"
+msgid "Unable to load profiles, perhaps we're not logged in."
+msgstr ""

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -280,3 +280,19 @@ msgstr ""
 msgctxt "#30069"
 msgid "Unable to load profiles, perhaps we're not logged in."
 msgstr ""
+
+msgctxt "#30070"
+msgid "Adult"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Child"
+msgstr ""
+
+msgctxt "#30072"
+msgid "owner"
+msgstr ""
+
+msgctxt "#30073"
+msgid "age restricted"
+msgstr ""

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -272,3 +272,11 @@ msgstr "Litauiska"
 msgctxt "#30067"
 msgid "viaplay.com/nl"
 msgstr ""
+
+msgctxt "#30068"
+msgid "Select profile"
+msgstr ""
+
+msgctxt "#30069"
+msgid "Unable to load profiles, perhaps we're not logged in."
+msgstr ""

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -280,3 +280,19 @@ msgstr ""
 msgctxt "#30069"
 msgid "Unable to load profiles, perhaps we're not logged in."
 msgstr ""
+
+msgctxt "#30070"
+msgid "Adult"
+msgstr ""
+
+msgctxt "#30071"
+msgid "Child"
+msgstr ""
+
+msgctxt "#30072"
+msgid "owner"
+msgstr ""
+
+msgctxt "#30073"
+msgid "age restricted"
+msgstr ""

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -125,7 +125,6 @@ def root():
     supported_pages = {
         'viaplay:root': start,
         'viaplay:search': search,
-        'viaplay:logout': log_out,
         'viaplay:starred': list_products,
         'viaplay:watched': list_products,
         'viaplay:purchased': list_products,
@@ -140,9 +139,6 @@ def root():
 
     for page in pages:
         page['title'] = capitalize(page['title'])
-
-        if 'logout' in page['href']:
-            page['title'] = helper.language(30042)
 
         if page['name'] in supported_pages:
             helper.add_item(page['title'], plugin.url_for(supported_pages[page['name']], url=page['href']))

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -327,6 +327,9 @@ def channels():
         helper.add_item(helper.language(30018), plugin.url_for(channels, url=channels_dict['next_page']))
     helper.eod()
 
+@plugin.route('/profiles')
+def profiles():
+    helper.profile_dialog()
 
 @plugin.route('/log_out')
 def log_out():

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -50,8 +50,9 @@ def run():
         plugin.run()
     except helper.vp.ViaplayError as error:
         missing_cookie = 'MissingSessionCookieError'
+        persistent_login = 'PersistentLoginError'
 
-        if error.value == missing_cookie:
+        if error.value == missing_cookie or error.value == persistent_login:
             if helper.authorize():
                 plugin.run()
         else:
@@ -121,6 +122,7 @@ def generate_m3u():
 
 @plugin.route('/')
 def root():
+    helper.ensure_profile()
     pages = helper.vp.get_root_page()
     supported_pages = {
         'viaplay:root': start,

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -182,7 +182,7 @@ class KodiHelper(object):
             current = -1
 
         index = self.dialog(dialog_type='select', heading=self.language(30068), options=names, preselect=current)
-        if index > -1:
+        if index != None:
             self.set_setting("profile_id", pids[index])
             self.log("Profile selected %s: %s" % (names[index], pids[index]))
             xbmc.executebuiltin('Container.Refresh')

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -82,14 +82,14 @@ class KodiHelper(object):
             return "com"
         return country_code
 
-    def dialog(self, dialog_type, heading, message=None, options=None, nolabel=None, yeslabel=None):
+    def dialog(self, dialog_type, heading, message=None, options=None, nolabel=None, yeslabel=None, preselect=-1):
         dialog = xbmcgui.Dialog()
         if dialog_type == 'ok':
             dialog.ok(heading, message)
         elif dialog_type == 'yesno':
             return dialog.yesno(heading, message, nolabel=nolabel, yeslabel=yeslabel)
         elif dialog_type == 'select':
-            ret = dialog.select(heading, options)
+            ret = dialog.select(heading, options, preselect=preselect)
             if ret > -1:
                 return ret
             else:
@@ -161,6 +161,25 @@ class KodiHelper(object):
 
         dialog.close()
         return False
+
+    def profile_dialog(self):
+        profiles = self.vp.get_profiles()
+        if len(profiles) == 0:
+            self.dialog(dialog_type='ok', heading=self.language(30068), message=self.language(30069))
+            return
+
+        pids = [profile['data']['id'] for profile in profiles]
+        names = [profile['data']['name'] for profile in profiles]
+        try:
+            current = pids.index(self.vp.get_profile_id())
+        except:
+            current = -1
+
+        index = self.dialog(dialog_type='select', heading=self.language(30068), options=names, preselect=current)
+        if index > -1:
+            self.set_setting("profile_id", pids[index])
+            self.log("Profile selected %s: %s" % (names[index], pids[index]))
+            xbmc.executebuiltin('Container.Refresh')
 
     def get_user_input(self, heading, hidden=False):
         keyboard = xbmc.Keyboard('', heading, hidden)

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -162,6 +162,12 @@ class KodiHelper(object):
         dialog.close()
         return False
 
+    def ensure_profile(self):
+        if not self.vp.get_user_id():
+            self.vp.validate_session()
+        if not self.vp.get_profile_id():
+            self.profile_dialog()
+
     def profile_dialog(self):
         profiles = self.vp.get_profiles()
         if len(profiles) == 0:

--- a/resources/lib/viaplay.py
+++ b/resources/lib/viaplay.py
@@ -166,6 +166,13 @@ class Viaplay(object):
 
     def make_request(self, url, method, params=None, payload=None, headers=None):
         """Make an HTTP request. Return the response."""
+        if params == None:
+            params = {}
+        
+        pid = self.get_profile_id()
+        if pid:
+            params['profileId'] = pid
+        
         try:
             return self._make_request(url, method, params=params, payload=payload, headers=headers)
         except self.ViaplayError:

--- a/resources/lib/viaplay.py
+++ b/resources/lib/viaplay.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 """
 A Kodi-agnostic library for Viaplay
 """

--- a/resources/lib/viaplay.py
+++ b/resources/lib/viaplay.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """
 A Kodi-agnostic library for Viaplay
 """
@@ -104,6 +104,20 @@ class Viaplay(object):
         if country_code == "nl":
             return "com"
         return country_code
+
+    def get_user_id(self):
+        return self.get_setting('user_id')
+
+    def get_profile_id(self):
+        return self.get_setting('profile_id')
+
+    def set_user_id(self, uid):
+        addon = self.get_addon()
+        addon.setSetting(id='user_id', value=uid)
+    
+    def set_profile_id(self, pid):
+        addon = self.get_addon()
+        addon.setSetting(id='profile_id', value=pid)
 
     def replace_cookies(self):
         cookie_file = os.path.join(self.addon_profile, 'cookie_file')

--- a/resources/lib/viaplay.py
+++ b/resources/lib/viaplay.py
@@ -231,7 +231,9 @@ class Viaplay(object):
         params = {
             'deviceKey': self.device_key
         }
-        self._make_request(url=url, method='get', params=params)
+        res = self._make_request(url=url, method='get', params=params)
+        if res and res['success'] == True:
+            self.set_user_id(res['userData']['userId'])
         return True
 
     def log_out(self):
@@ -247,8 +249,9 @@ class Viaplay(object):
             if os.path.exists(cookie_file):
                 os.remove(cookie_file)
 
+            self.set_user_id("")
+            self.set_profile_id("")
             xbmc.executebuiltin('Container.Update')
-
             xbmc.executebuiltin("Dialog.Close(all, true)")
             xbmc.executebuiltin("ActivateWindow(Home)")
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,10 +1,14 @@
-﻿<settings>
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
   <category label="30003">
-    <setting id="site" type="enum" label="30007" lvalues="30008|30009|30010|30011|30054|30065|30067" default="0"/>
+    <setting id="site" type="select" label="30007" lvalues="30008|30009|30010|30011|30054|30065|30067" default="0"/>
+    <setting id="user_id" type="text" default="" visible="true" enable="false" />
+    <setting id="profile_id" type="text" default="" visible="true" enable="false" />
+
     <setting id="subtitles" type="bool" label="30012" default="true"/>
     <setting id="first_run" type="bool" default="true" visible="false"/>
-	<setting type="sep" />
-	<setting id="previous_channels" type="bool" label="30056" default="false"/>
+    <setting type="sep" />
+	  <setting id="previous_channels" type="bool" label="30056" default="false"/>
     <setting type="sep" />
     <setting id="ia_settings" type="action" label="30053" action="RunPlugin(plugin://plugin.video.viaplay/ia_settings)" enable="System.HasAddon(inputstream.adaptive)" option="close" />
   </category>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,10 +1,11 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
   <category label="30003">
     <setting id="site" type="select" label="30007" lvalues="30008|30009|30010|30011|30054|30065|30067" default="0"/>
     <setting id="user_id" type="text" default="" visible="true" enable="false" />
     <setting id="profile_id" type="text" default="" visible="true" enable="false" />
     <setting id="profile_picker" label="30068" visible="!eq(-2,)" type="action" action="RunPlugin(plugin://plugin.video.viaplay/profiles)" />
+    <setting id="log_out" label="30042" visible="!eq(-3,)" type="action" action="RunPlugin(plugin://plugin.video.viaplay/log_out)" option="close" />
 
     <setting id="subtitles" type="bool" label="30012" default="true"/>
     <setting id="first_run" type="bool" default="true" visible="false"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,9 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
   <category label="30003">
     <setting id="site" type="select" label="30007" lvalues="30008|30009|30010|30011|30054|30065|30067" default="0"/>
     <setting id="user_id" type="text" default="" visible="true" enable="false" />
     <setting id="profile_id" type="text" default="" visible="true" enable="false" />
+    <setting id="profile_picker" label="30068" visible="!eq(-2,)" type="action" action="RunPlugin(plugin://plugin.video.viaplay/profiles)" />
 
     <setting id="subtitles" type="bool" label="30012" default="true"/>
     <setting id="first_run" type="bool" default="true" visible="false"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -6,7 +6,7 @@
     <setting id="profile_id" type="text" default="" visible="true" enable="false" />
     <setting id="profile_picker" label="30068" visible="!eq(-2,)" type="action" action="RunPlugin(plugin://plugin.video.viaplay/profiles)" />
     <setting id="log_out" label="30042" visible="!eq(-3,)" type="action" action="RunPlugin(plugin://plugin.video.viaplay/log_out)" option="close" />
-
+    <setting type="sep" />
     <setting id="subtitles" type="bool" label="30012" default="true"/>
     <setting id="first_run" type="bool" default="true" visible="false"/>
     <setting type="sep" />


### PR DESCRIPTION
Fixes https://github.com/emilsvennesson/kodi-viaplay/issues/34

Making a draft PR to get your feedback on this so far. It adds "Select profile" and "Log out" to the settings.
(As well as the user_id and profile_id, while it's in development, final would hide those.)

![image](https://user-images.githubusercontent.com/497556/160424249-64ee2ee6-4b75-4798-a558-239229f9f2f0.png)

It will automatically ask to choose a profile when opening the root page, if you haven't already.
Kind of like the "Who's watching?" dialog on the official apps.

An easy way to verify your profile is correctly selected, is to see if `viaplay:starred` or `viaplay:watched` has the correct items.

@Mariusz89B @heppen-dev @zuzia-dev
What's your opinion on using the settings menu like this, instead of adding it to the root page?